### PR TITLE
Fix installation error by updating pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ version = "0.0.1-dev"
 dependencies = [
     "torch",
     "lightning",
-    "git+https://github.com/discovery-unicamp/hiaac-librep.git@0.0.4-dev",
+    "librep@git+https://github.com/discovery-unicamp/hiaac-librep.git@0.0.4-dev",
     "scipy",
     "plotly",
     "numpy",
@@ -36,3 +36,7 @@ dev = ["mock", "pytest", "black", "isort"]
 
 "Bug Tracker" = "https://github.com/otavioon/ssl_tools/issues"
 "Homepage" = "https://github.com/otavioon/ssl_tools"
+
+[tool.setuptools]
+py-modules = ["ssl_tools"]
+


### PR DESCRIPTION
Make two changes to pyproject.toml:

Update `project.dependencies[2]` so it is pep508

Added

```
[tool.setuptools]
py-modules = ["ssl_tools"]
```
so setuptools recognizes only ssl_tools directory as package (and ignores /data).

